### PR TITLE
Replace yield inside for loop with yield from

### DIFF
--- a/fprime_fpp_install.py
+++ b/fprime_fpp_install.py
@@ -286,7 +286,6 @@ def clean_install_fpp():
 
     def lazy_loader():
         """Prevents the download of FPP items until actually enumerated"""
-        for item in iterate_fpp_tools(WORKING_DIR):
-            yield item
+        yield from iterate_fpp_tools(WORKING_DIR)
 
     yield lazy_loader()


### PR DESCRIPTION
This PR aims to replace ``yield`` in ``for`` loops by ``yield from``.

A lesser-known trick is that Python's ``yield`` keyword has a corresponding ``yield`` for collections, which eliminates the need to iterate over a collection with a ``for`` loop.
Therefore, using a ``for`` loop to iterate over a collection is unnecessary.

This shortens the code slightly and eliminates the mental load and extra variable used by the ``for`` loop. By removing the ``for`` loop, the performance of the version would become 15% faster.
